### PR TITLE
Fix session-start script shell compatibility

### DIFF
--- a/src/core/common.sh
+++ b/src/core/common.sh
@@ -17,11 +17,12 @@ check_required_tools() {
     local config_file="$1"
     local missing_tools=()
     
-    while IFS= read -r tool; do
+    # Get required tools and check each one
+    for tool in $(yq eval '.tools.required[]' "$config_file"); do
         if ! command_exists "$tool"; then
             missing_tools+=("$tool")
         fi
-    done < <(yq eval '.tools.required[]' "$config_file")
+    done
     
     if [ ${#missing_tools[@]} -ne 0 ]; then
         echo -e "${RED}Missing required tools:${NC}"


### PR DESCRIPTION
This PR fixes a shell compatibility issue in the session-start script by replacing process substitution with a more compatible for loop approach.

Changes:
- Modified check_required_tools function to use a standard for loop
- Improved shell compatibility across different environments
- Removed syntax error when running with sh

Tested:
- Verified script runs without errors using sh
- Confirmed required tools checking still works as expected