### PR TITLE
Fix GitHub Pages configuration and paths

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,6 @@
+name: Dev Session Buddy
+title: Dev Session Buddy - Your AI-Powered Development Companion
+description: Standardize development session workflows and improve collaboration between developers and AI assistants
+url: https://codevalve.github.io
+baseurl: /dev-session-buddy
+permalink: pretty

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,10 +13,10 @@
     <meta property="og:url" content="https://codevalve.github.io/dev-session-buddy/">
     <meta name="twitter:card" content="summary_large_image">
     
-    <link rel="stylesheet" href="assets/css/styles.css">
+    <link rel="stylesheet" href="/dev-session-buddy/assets/css/styles.css">
     <!-- Preload critical assets -->
-    <link rel="preload" as="image" href="assets/images/logo-light.png">
-    <link rel="preload" as="image" href="assets/images/logo-dark.png">
+    <link rel="preload" as="image" href="/dev-session-buddy/assets/images/logo-light.png">
+    <link rel="preload" as="image" href="/dev-session-buddy/assets/images/logo-dark.png">
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,8 +36,8 @@
         <div class="container">
             <nav>
                 <div class="logo">
-                    <img src="assets/images/logo-dark.png" alt="Dev Session Buddy Logo" width="50" height="50" class="logo-dark">
-                    <img src="assets/images/logo-light.png" alt="Dev Session Buddy Logo" width="50" height="50" class="logo-light">
+                    <img src="/dev-session-buddy/assets/images/logo-dark.png" alt="Dev Session Buddy Logo" width="50" height="50" class="logo-dark">
+                    <img src="/dev-session-buddy/assets/images/logo-light.png" alt="Dev Session Buddy Logo" width="50" height="50" class="logo-light">
                     <span>Dev Session Buddy</span>
                 </div>
                 <div class="nav-links">
@@ -59,7 +59,7 @@
                         <a href="https://github.com/codevalve/dev-session-buddy" class="secondary-btn">View on GitHub</a>
                     </div>
                 </div>
-                <div class="hero-image loading-placeholder" data-src="assets/images/hero.png">
+                <div class="hero-image loading-placeholder" data-src="/dev-session-buddy/assets/images/hero.png">
                     <!-- Placeholder gradient until image loads -->
                 </div>
             </div>
@@ -127,8 +127,8 @@ cd dev-session-buddy
         <div class="container">
             <div class="footer-content">
                 <div class="footer-logo">
-                    <img src="assets/images/logo-dark.png" alt="Dev Session Buddy Logo" width="40" height="40" class="logo-dark">
-                    <img src="assets/images/logo-light.png" alt="Dev Session Buddy Logo" width="40" height="40" class="logo-light">
+                    <img src="/dev-session-buddy/assets/images/logo-dark.png" alt="Dev Session Buddy Logo" width="40" height="40" class="logo-dark">
+                    <img src="/dev-session-buddy/assets/images/logo-light.png" alt="Dev Session Buddy Logo" width="40" height="40" class="logo-light">
                     <span>Dev Session Buddy</span>
                 </div>
                 <div class="footer-links">
@@ -144,6 +144,6 @@ cd dev-session-buddy
         </div>
     </footer>
 
-    <script src="assets/js/main.js"></script>
+    <script src="/dev-session-buddy/assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR improves the GitHub Pages setup to work without requiring /index.html in the URL.

Changes:
- Add _config.yml with proper GitHub Pages configuration
- Update all asset paths to use absolute paths with baseurl
- Keep .nojekyll file for proper asset serving

After merging, the site should be accessible at:
https://codevalve.github.io/dev-session-buddy/

All assets (images, CSS, JS) should load correctly with the proper paths.